### PR TITLE
find completions' common prefix case-insensitively

### DIFF
--- a/System/Console/Haskeline/Command/Completion.hs
+++ b/System/Console/Haskeline/Command/Completion.hs
@@ -14,6 +14,7 @@ import System.Console.Haskeline.Prefs
 import System.Console.Haskeline.Completion
 import System.Console.Haskeline.Monads
 
+import Data.Char(toLower)
 import Data.List(transpose, unfoldr)
 
 useCompletion :: InsertMode -> Completion -> InsertMode
@@ -64,7 +65,7 @@ makePartialCompletion :: InsertMode -> [Completion] -> InsertMode
 makePartialCompletion im completions = insertString partial im
   where
     partial = foldl1 commonPrefix (map replacement completions)
-    commonPrefix (c:cs) (d:ds) | c == d = c : commonPrefix cs ds
+    commonPrefix (c:cs) (d:ds) | toLower c == toLower d = c : commonPrefix cs ds
     commonPrefix _ _ = ""
 
 pagingCompletion :: MonadReader Layout m => Key -> Prefs


### PR DESCRIPTION
Hi Judah, thanks for an awesome library.

This lets me do case-insensitive completion in hledger add. Otherwise haskeline truncates completions to their common case-matched prefix, which is often a short or empty string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/judah/haskeline/7)
<!-- Reviewable:end -->
