### PR TITLE
Improve Windows support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto
+*.c text
+*.hs* text
+*.h text
+*.txt text
+*.sh text
+Makefile text
+*.md text
+LICENSE text
+README* text
+Changelog text
+*.y*ml text
+.git* text
+*.cabal text

--- a/System/Console/Haskeline/InputT.hs
+++ b/System/Console/Haskeline/InputT.hs
@@ -11,13 +11,10 @@ import System.Console.Haskeline.Completion
 import System.Console.Haskeline.Backend
 import System.Console.Haskeline.Term
 
-import Control.Exception (IOException)
 import Control.Monad.Catch
 import Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Data.IORef
-import System.Directory(getHomeDirectory)
-import System.FilePath
 import System.IO
 
 -- | Application-specific customizations to the user interface.
@@ -143,7 +140,7 @@ withBehavior (Behavior run) f = bracket (liftIO run) (liftIO . closeTerm) f
 runInputTBehavior :: (MonadIO m, MonadMask m) => Behavior -> Settings m -> InputT m a -> m a
 runInputTBehavior behavior settings f = withBehavior behavior $ \run -> do
     prefs <- if isTerminalStyle run
-                then liftIO readPrefsFromHome
+                then liftIO readPrefs
                 else return defaultPrefs
     execInputT prefs settings run f
 
@@ -194,12 +191,3 @@ useFile file = Behavior $ do
 -- If it cannot open the user's terminal, use file-style interaction, reading input from 'stdin'.
 preferTerm :: Behavior
 preferTerm = Behavior terminalRunTerm
-
-
--- | Read 'Prefs' from @~/.haskeline.@   If there is an error reading the file,
--- the 'defaultPrefs' will be returned.
-readPrefsFromHome :: IO Prefs
-readPrefsFromHome = handle (\(_::IOException) -> return defaultPrefs) $ do
-    home <- getHomeDirectory
-    readPrefs (home </> ".haskeline")
-

--- a/System/Console/Haskeline/InputT.hs
+++ b/System/Console/Haskeline/InputT.hs
@@ -140,7 +140,7 @@ withBehavior (Behavior run) f = bracket (liftIO run) (liftIO . closeTerm) f
 runInputTBehavior :: (MonadIO m, MonadMask m) => Behavior -> Settings m -> InputT m a -> m a
 runInputTBehavior behavior settings f = withBehavior behavior $ \run -> do
     prefs <- if isTerminalStyle run
-                then liftIO readPrefs
+                then liftIO readPrefsFromHome
                 else return defaultPrefs
     execInputT prefs settings run f
 

--- a/System/Console/Haskeline/Prefs.hs
+++ b/System/Console/Haskeline/Prefs.hs
@@ -2,6 +2,7 @@ module System.Console.Haskeline.Prefs(
                         Prefs(..),
                         defaultPrefs,
                         readPrefs,
+                        readPrefsFromHome,
                         CompletionType(..),
                         BellStyle(..),
                         EditMode(..),
@@ -150,8 +151,8 @@ getFirst = fmap listToMaybe
 
 -- | Read 'Prefs' from a given file.  If there is an error reading the file,
 -- the 'defaultPrefs' will be returned.
-readPrefsFromFile :: FilePath -> IO Prefs
-readPrefsFromFile path = handle (\(_::IOException) -> do
+readPrefs :: FilePath -> IO Prefs
+readPrefs path = handle (\(_::IOException) -> do
                            hPutStrLn stderr ("haskeline: can't read preferences from " ++ path ++ ".")
                            return defaultPrefs) $ do
     ls <- fmap lines $ readFile path
@@ -178,5 +179,5 @@ readPreferences exceptionHandler preferencesFromPath getPath = handle (\(_::IOEx
 findPreferencePath :: IO (Maybe FilePath)
 findPreferencePath = getFirst $ filterPaths doesFileExist getConfigurationPaths
 
-readPrefs :: IO Prefs
-readPrefs = readPreferences fallback readPrefsFromFile findPreferencePath
+readPrefsFromHome :: IO Prefs
+readPrefsFromHome = readPreferences fallback readPrefs findPreferencePath

--- a/System/Console/Haskeline/Prefs.hs
+++ b/System/Console/Haskeline/Prefs.hs
@@ -13,7 +13,6 @@ import Control.Monad.Catch(handle)
 import Control.Monad(filterM)
 import Control.Exception (IOException)
 import Data.Char(isSpace,toLower)
-import Data.Functor((<&>))
 import Data.List(foldl')
 import Data.Maybe(listToMaybe)
 import qualified Data.Map as Map
@@ -133,6 +132,9 @@ addCustomKeySequence str = maybe id addKS maybeParse
 
 lookupKeyBinding :: Key -> Prefs -> [Key]
 lookupKeyBinding k = Map.findWithDefault [k] k . customBindings
+
+(<&>) :: Functor f => f a -> (a -> b) -> f b
+(<&>) = flip fmap
 
 configurationFilePaths :: IO [FilePath]
 configurationFilePaths = sequence [


### PR DESCRIPTION
Looking for preferences in `$XDG_CONFIG_HOME` or `%APPDATA%` improves standards conformance. In addition to resulting in a more predictable preference file location on Windows NT, it enables tidier ~ directories on all platforms. Declaring the text files in this repository as using LF terminated lines improves the contribution experience on legacy operating systems such as DOS, Windows and classic (pre-Darwin) Mac OS.