### PR TITLE
Fix #130 Don't skip "\ESC...\STX" sequences (when terminal-style) 

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,10 @@
+Changed in version UNRELEASED:
+
+   * On Windows, when terminal-style and printing output, no longer skips
+     `"\ESC...\STX"` sequences. (If used with legacy ConHost directly (for
+     example, `conhost.exe cmd.exe`), it will require ConHost's ANSI-capability
+     to be enabled separately.) (#126)
+
 Changed in version 0.8.4.0:
 
    * Added `System.Console.Haskeline.ReaderT` module for `ReaderT` interface.

--- a/System/Console/Haskeline/Backend/Win32.hsc
+++ b/System/Console/Haskeline/Backend/Win32.hsc
@@ -381,9 +381,7 @@ crlf :: String
 crlf = "\r\n"
 
 instance (MonadMask m, MonadIO m, MonadReader Layout m) => Term (Draw m) where
-    drawLineDiff (xs1,ys1) (xs2,ys2) = let
-        fixEsc = filter ((/= '\ESC') . baseChar)
-        in drawLineDiffWin (fixEsc xs1, fixEsc ys1) (fixEsc xs2, fixEsc ys2)
+    drawLineDiff = drawLineDiffWin
     -- TODO now that we capture resize events.
     -- first, looks like the cursor stays on the same line but jumps
     -- to the beginning if cut off.

--- a/System/Console/Haskeline/Backend/Win32.hsc
+++ b/System/Console/Haskeline/Backend/Win32.hsc
@@ -8,21 +8,24 @@ module System.Console.Haskeline.Backend.Win32(
 
 
 import System.IO
-import System.IO.Unsafe (unsafePerformIO)
 import Foreign
 import Foreign.C
 #if MIN_VERSION_Win32(2,14,1)
-import System.Win32 hiding (KeyEvent, getConsoleMode, isMinTTY, keyDown,
-                           multiByteToWideChar, repeatCount, setConsoleMode,
-                           try, virtualKeyCode, virtualScanCode, windowSize)
+import System.Win32 hiding (
+                multiByteToWideChar,
+                setConsoleMode,
+                getConsoleMode,
+                KeyEvent,
+                keyDown,
+                virtualKeyCode,
+                repeatCount,
+                virtualScanCode,
+                windowSize
+                )
 #elif MIN_VERSION_Win32(2,9,0)
-import System.Win32 hiding (getConsoleMode, isMinTTY, multiByteToWideChar,
-                           setConsoleMode, try)
-#elif MIN_VERSION_Win32(2,5,0)
-import System.Win32 hiding (isMinTTY, multiByteToWideChar, try)
+import System.Win32 hiding (multiByteToWideChar, setConsoleMode, getConsoleMode)
 #else
-import System.Win32 hiding (multiByteToWideChar, try)
-import System.Console.Mintty (isMinTTYHandle)
+import System.Win32 hiding (multiByteToWideChar)
 #endif
 import Graphics.Win32.Misc(getStdHandle, sTD_OUTPUT_HANDLE)
 import Data.List(intercalate)
@@ -30,7 +33,7 @@ import Control.Concurrent.STM
 import Control.Concurrent hiding (throwTo)
 import Data.Char(isPrint, chr, ord)
 import Data.Maybe(mapMaybe)
-import Control.Exception (IOException, SomeException, throwTo, try)
+import Control.Exception (IOException, throwTo)
 import Control.Monad
 import Control.Monad.Catch
     ( MonadThrow
@@ -270,26 +273,16 @@ foreign import WINDOWS_CCONV "windows.h GetConsoleMode" c_GetConsoleMode
 foreign import WINDOWS_CCONV "windows.h SetConsoleMode" c_SetConsoleMode
     :: HANDLE -> DWORD -> IO Bool
 
-#if !MIN_VERSION_Win32(2,8,5)
-eNABLE_VIRTUAL_TERMINAL_PROCESSING :: DWORD
-eNABLE_VIRTUAL_TERMINAL_PROCESSING =   4
-#endif
-
 withWindowMode :: (MonadIO m, MonadMask m) => Handles -> m a -> m a
 withWindowMode hs f = do
     let h = hIn hs
     bracket (getConsoleMode h) (setConsoleMode h)
             $ \m -> setConsoleMode h (m .|. (#const ENABLE_WINDOW_INPUT)) >> f
-
-getConsoleMode :: (MonadIO m) => HANDLE -> m DWORD
-getConsoleMode h = liftIO $ alloca $ \p -> do
-    failIfFalse_ "GetConsoleMode" $ c_GetConsoleMode h p
-    peek p
-
-setConsoleMode :: (MonadIO m) => HANDLE -> DWORD -> m ()
-setConsoleMode h m =
-    liftIO $ failIfFalse_ "SetConsoleMode" $ c_SetConsoleMode h m
-
+  where
+    getConsoleMode h = liftIO $ alloca $ \p -> do
+            failIfFalse_ "GetConsoleMode" $ c_GetConsoleMode h p
+            peek p
+    setConsoleMode h m = liftIO $ failIfFalse_ "SetConsoleMode" $ c_SetConsoleMode h m
 
 ----------------------------
 -- Drawing
@@ -388,11 +381,9 @@ crlf :: String
 crlf = "\r\n"
 
 instance (MonadMask m, MonadIO m, MonadReader Layout m) => Term (Draw m) where
-    drawLineDiff (xs1,ys1) (xs2,ys2) = if aNSISupport
-      then drawLineDiffWin (xs1,ys1) (xs2,ys2)
-      else
-        let fixEsc = filter ((/= '\ESC') . baseChar)
-        in  drawLineDiffWin (fixEsc xs1, fixEsc ys1) (fixEsc xs2, fixEsc ys2)
+    drawLineDiff (xs1,ys1) (xs2,ys2) = let
+        fixEsc = filter ((/= '\ESC') . baseChar)
+        in drawLineDiffWin (fixEsc xs1, fixEsc ys1) (fixEsc xs2, fixEsc ys2)
     -- TODO now that we capture resize events.
     -- first, looks like the cursor stays on the same line but jumps
     -- to the beginning if cut off.
@@ -588,35 +579,3 @@ clearScreen = do
     liftIO $ fillConsoleChar h ' ' windowSize origin
     liftIO $ fillConsoleAttribute h attr windowSize origin
     setPos origin
-
--- | This function assumes that once it is first established whether or not the
--- Windows console is ANSI-capable, that will not change.
-{-# NOINLINE aNSISupport #-}
-aNSISupport :: Bool
-aNSISupport = unsafePerformIO $ withHandleToHANDLE stdout $ withHANDLE
-  (return False)  -- Invalid handle or no handle
-  $ \h -> do
-    tryMode <- try (getConsoleMode h) :: IO (Either SomeException DWORD)
-    case tryMode of
-      Left _     -> do  -- No ConHost mode
-        isMinTTY <- isMinTTYHandle h
-        if isMinTTY
-          then return True  -- 'mintty' terminal emulator
-          else return False  -- Not sure!
-      Right mode -> if mode .&. eNABLE_VIRTUAL_TERMINAL_PROCESSING /= 0
-        then return True  -- VT processing already enabled
-        else do
-          let mode' = mode .|. eNABLE_VIRTUAL_TERMINAL_PROCESSING
-          trySetMode <- try (setConsoleMode h mode')
-            :: IO (Either SomeException ())
-          case trySetMode of
-            Left _   -> return False  -- Can't enable VT processing
-            Right () -> return True  -- VT processing enabled
- where
-  -- | This function applies another to the Windows handle, if the handle is
-  -- valid. If it is invalid, the specified default action is returned.
-  withHANDLE :: IO a -> (HANDLE -> IO a) -> HANDLE -> IO a
-  withHANDLE invalid action h =
-    if h == iNVALID_HANDLE_VALUE || h == nullHANDLE
-      then invalid  -- Invalid handle or no handle
-      else action h

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -113,7 +113,7 @@ Library
     c-sources: cbits/h_wcwidth.c
 
     if os(windows)
-        Build-depends: Win32 >= 2.1 && < 2.10 || >= 2.12
+        Build-depends: Win32 >= 2.1 && < 2.10 || >= 2.12, mintty
         Other-modules: System.Console.Haskeline.Backend.Win32
                        System.Console.Haskeline.Backend.Win32.Echo
         c-sources: cbits/win_console.c

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -113,7 +113,7 @@ Library
     c-sources: cbits/h_wcwidth.c
 
     if os(windows)
-        Build-depends: Win32 >= 2.1 && < 2.10 || >= 2.12, mintty
+        Build-depends: Win32 >= 2.1 && < 2.10 || >= 2.12
         Other-modules: System.Console.Haskeline.Backend.Win32
                        System.Console.Haskeline.Backend.Win32.Echo
         c-sources: cbits/win_console.c


### PR DESCRIPTION
This reverses commit f827f10145380ec9e685a72e4b8a7a27ef6717ea of 11 September 2010 (about 5 years before the November 2015 Update to Windows 10 made the native consoles on Windows 10 ANSI-capable). Applications like `GHCi` and `stack` enable the ANSI-capability of the native consoles. 

In respect of legacy Windows, none of them have mainstream support by Microsoft and Windows 7 loses extended support on 14 January 2020.

It has been tested on Windows 10 with
````haskell
module Main where

import System.Console.Haskeline

main :: IO ()
main = runInputT defaultSettings loop
 where
  prompt = "\ESC[34m\STXBlue\ESC[39m\STX\n\ESC[31m\STXRed\ESC[39m\STX: "
  loop :: InputT IO ()
  loop = do
    minput <- getInputLine prompt
    case minput of
      Nothing -> pure ()
      Just "quit" -> pure ()
      Just input -> do outputStrLn $ "Input was: " ++ input
                       loop
````