### PR TITLE
Added XDG support

### DIFF
--- a/System/Console/Haskeline/InputT.hs
+++ b/System/Console/Haskeline/InputT.hs
@@ -222,7 +222,7 @@ preferTerm = Behavior terminalRunTerm
 -- the 'defaultPrefs' will be returned.
 readUserPrefs :: IO Prefs
 readUserPrefs = handle (\(_::IOException) -> return defaultPrefs) $ do
-    xdg    <- getXdgDirectory XdgConfig ("haskline/haskeline")
+    xdg    <- getXdgDirectory XdgConfig ("haskeline/haskeline")
     exists <- doesFileExist xdg
     home   <- getHomeDirectory
     readPrefs (if exists then xdg else (home </> ".haskeline"))


### PR DESCRIPTION
solving issue #150 

renamed readPrefsFromHome -> readUserPrefs
made readUserPrefs look for $XDG_CONFIG_HOME, check if it exists
and if so, readPrefs from it instead of $HOME/.haskeline.
If it doesen't exist, readPref from $HOME/.haskeline.