### PR TITLE
Fix #159: exclude Win32-2.10/11

### DIFF
--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -94,7 +94,7 @@ Library
     c-sources: cbits/h_wcwidth.c
 
     if os(windows) {
-        Build-depends: Win32>=2.0
+        Build-depends: Win32 >= 2.1 && < 2.10 || >= 2.12
         Other-modules: System.Console.Haskeline.Backend.Win32
                        System.Console.Haskeline.Backend.Win32.Echo
         c-sources: cbits/win_console.c


### PR DESCRIPTION
Fix #159: exclude Win32-2.10/11.
`haskeline >= 0.7.2.3` fails to build with `Win32-2.10/11` because of duplicate definitions:
```
    Ambiguous occurrence `c_WaitForSingleObject'
    It could refer to
       either `System.Win32.c_WaitForSingleObject',
              imported from `System.Win32' at System\Console\Haskeline\Backend\Win32.hsc:14:1-80
              (and originally defined in `System.Win32.Event')
           or `System.Console.Haskeline.Backend.Win32.c_WaitForSingleObject',
              defined at dist\build\System\Console\Haskeline\Backend\Win32.hs:51:1
```