### PR TITLE
Add support Windows Aarch64 (bump versions)

### DIFF
--- a/System/Console/Haskeline/Backend/Win32.hsc
+++ b/System/Console/Haskeline/Backend/Win32.hsc
@@ -10,7 +10,19 @@ module System.Console.Haskeline.Backend.Win32(
 import System.IO
 import Foreign
 import Foreign.C
-#if MIN_VERSION_Win32(2,9,0)
+#if MIN_VERSION_Win32(2,14,1)
+import System.Win32 hiding (
+                multiByteToWideChar,
+                setConsoleMode,
+                getConsoleMode,
+                KeyEvent,
+                InputEvent,
+                keyDown,
+                virtualKeyCode,
+                repeatCount,
+                virtualScanCode
+                )
+#elif MIN_VERSION_Win32(2,9,0)
 import System.Win32 hiding (multiByteToWideChar, setConsoleMode, getConsoleMode)
 #else
 import System.Win32 hiding (multiByteToWideChar)

--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -63,7 +63,7 @@ Library
     -- We require ghc>=7.4.1 (base>=4.5) to use the base library encodings, even
     -- though it was implemented in earlier releases, due to GHC bug #5436 which
     -- wasn't fixed until 7.4.1
-    Build-depends: base >=4.9 && < 4.20, containers>=0.4 && < 0.8,
+    Build-depends: base >=4.9 && < 4.22, containers>=0.4 && < 0.8,
                    directory>=1.1 && < 1.4, bytestring>=0.9 && < 0.13,
                    filepath >= 1.2 && < 1.6, transformers >= 0.2 && < 0.7,
                    process >= 1.0 && < 1.7, stm >= 2.4 && < 2.6,


### PR DESCRIPTION
We continue the adding support Windows Aarch64 (bump versions)

* bump `base` to latest
* bump `Win32` support to latest