### PR TITLE
Add support Windows Aarch64 (fix ghc warnings)

### DIFF
--- a/System/Console/Haskeline/Backend/Win32.hsc
+++ b/System/Console/Haskeline/Backend/Win32.hsc
@@ -16,11 +16,11 @@ import System.Win32 hiding (
                 setConsoleMode,
                 getConsoleMode,
                 KeyEvent,
-                InputEvent,
                 keyDown,
                 virtualKeyCode,
                 repeatCount,
-                virtualScanCode
+                virtualScanCode,
+                windowSize
                 )
 #elif MIN_VERSION_Win32(2,9,0)
 import System.Win32 hiding (multiByteToWideChar, setConsoleMode, getConsoleMode)


### PR DESCRIPTION
The following https://gitlab.haskell.org/ghc/ghc/-/jobs/2098586

```
===> Command failed with error code: 1
libraries\haskeline\System\Console\Haskeline\Backend\Win32.hsc:19:17: error: [GHC-61689] [-Wdodgy-imports, Werror=dodgy-imports]
    Module `System.Win32' does not export `InputEvent'.
   |
19 |                 InputEvent,
   |                 ^^^^^^^^^^
libraries\haskeline\System\Console\Haskeline\Backend\Win32.hsc:576:9: error: [GHC-63397] [-Wname-shadowing, Werror=name-shadowing]
    This binding for `windowSize' shadows the existing binding
      imported from `System.Win32' at libraries\haskeline\System\Console\Haskeline\Backend\Win32.hsc:(14,1)-(24,17)
      (and originally defined in `Win32-2.14.1.0:System.Win32.Console.Internal')
    |
576 |     let windowSize = width lay * height lay
    |         ^^^^^^^^^^
```