### PR TITLE
Note wiki link about \ESC...\STX in haddocks

### DIFF
--- a/System/Console/Haskeline.hs
+++ b/System/Console/Haskeline.hs
@@ -144,6 +144,10 @@ They return `Nothing` if they encounter the end of input.  More specifically:
 
 If @'autoAddHistory' == 'True'@ and the line input is nonblank (i.e., is not all
 spaces), it will be automatically added to the history.
+
+To include ANSI escape sequences in the input prompt, terminate them by @\STX@.
+See <https://github.com/haskell/haskeline/wiki/ControlSequencesInPrompt> for
+more information.
 -}
 getInputLine :: (MonadIO m, MonadMask m)
             => String -- ^ The input prompt


### PR DESCRIPTION
The `\STX`-handling functionality is rather hard to discover: it's nowhere in the haddocks, only only on the GitHub wiki (which is not linked anywhere from Hackage, as the README is also not included on Hackage). (It is implemented in `stringToGraphemes` [here](https://github.com/haskell/haskeline/blob/105b62bc6bbacc67b13a38bfcd31423ea1e441db/System/Console/Haskeline/LineState.hs#L109).) Furthermore, this functionality is also not "standard": `bash` parses `\[` and `\]` specially to `readline` tokens (currently [here](https://git.savannah.gnu.org/cgit/bash.git/tree/y.tab.c#n8330)); they may happen to be `\001` and `\002`, but this is an implementation detail more than anything else.

This is a small patch to make this functionality more discoverable. (I wanted it in `ghci`.)

More broadly, it would be nice if the README was included on Hackage, because that at least links to the GitHub wiki (though under the old `/judah/` path). Some people [on IRC](https://ircbrowse.tomsmeding.com/day/lchaskell/2025/03/02?id=1494270#trid1494270) claim that it is sufficient to add `README.md` to `extra-source-files` in `haskeline.cabal`, but I have not checked whether this is accurate.