### PR TITLE
Bump base upper bound to <4.23

### DIFF
--- a/haskeline.cabal
+++ b/haskeline.cabal
@@ -63,7 +63,7 @@ flag examples
 
 Library
     Build-depends:
-        base         >= 4.9 && < 4.22
+        base         >= 4.9 && < 4.23
       , containers   >= 0.4 && < 0.9
       , directory    >= 1.1 && < 1.4
       , bytestring   >= 0.9 && < 0.13


### PR DESCRIPTION
Allowing GHC 9.14.