### PR TITLE
Use (>=>) from Control.Monad instead of custom (>|>)

### DIFF
--- a/System/Console/Haskeline.hs
+++ b/System/Console/Haskeline.hs
@@ -91,6 +91,7 @@ import System.Console.Haskeline.Term
 import System.Console.Haskeline.Key
 import System.Console.Haskeline.RunCommand
 
+import Control.Monad ((>=>))
 import Control.Monad.Catch (MonadMask, handle)
 import Data.Char (isSpace, isPrint)
 import Data.Maybe (isJust)
@@ -232,7 +233,7 @@ getInputCmdChar tops prefix = runInputCmdT tops
 acceptOneChar :: Monad m => KeyCommand m InsertMode (Maybe Char)
 acceptOneChar = choiceCmd [useChar $ \c s -> change (insertChar c) s
                                                 >> return (Just c)
-                          , ctrlChar 'l' +> clearScreenCmd >|>
+                          , ctrlChar 'l' +> clearScreenCmd >=>
                                         keyCommand acceptOneChar
                           , ctrlChar 'd' +> failCmd]
 
@@ -286,12 +287,12 @@ getPassword x = promptedInput
  where
     loop = choiceCmd [ simpleChar '\n' +> finish
                      , simpleKey Backspace +> change deletePasswordChar
-                                                >|> loop'
-                     , useChar $ \c -> change (addPasswordChar c) >|> loop'
+                                                >=> loop'
+                     , useChar $ \c -> change (addPasswordChar c) >=> loop'
                      , ctrlChar 'd' +> \p -> if null (passwordState p)
                                                 then failCmd p
                                                 else finish p
-                     , ctrlChar 'l' +> clearScreenCmd >|> loop'
+                     , ctrlChar 'l' +> clearScreenCmd >=> loop'
                      ]
     loop' = keyCommand loop
 

--- a/System/Console/Haskeline/Command/Completion.hs
+++ b/System/Console/Haskeline/Command/Completion.hs
@@ -15,6 +15,7 @@ import System.Console.Haskeline.Prefs
 import System.Console.Haskeline.Completion
 import System.Console.Haskeline.Monads
 
+import Control.Monad ((>=>))
 import Data.List(transpose, unfoldr)
 
 useCompletion :: InsertMode -> Completion -> InsertMode
@@ -35,7 +36,7 @@ askIMCompletions (IMode xs ys) = do
 -- | Create a 'Command' for word completion.
 completionCmd :: (MonadState Undo m, CommandMonad m)
                 => Key -> KeyCommand m InsertMode InsertMode
-completionCmd k = k +> saveForUndo >|> \oldIM -> do
+completionCmd k = k +> saveForUndo >=> \oldIM -> do
     (rest,cs) <- askIMCompletions oldIM
     case cs of
         [] -> effect RingBell >> return oldIM
@@ -59,7 +60,7 @@ menuCompletion :: Monad m => Key -> [InsertMode] -> Command m InsertMode InsertM
 menuCompletion k = loop
     where
         loop [] = setState
-        loop (c:cs) = change (const c) >|> try (k +> loop cs)
+        loop (c:cs) = change (const c) >=> try (k +> loop cs)
 
 makePartialCompletion :: InsertMode -> [Completion] -> InsertMode
 makePartialCompletion im completions = insertString partial im

--- a/System/Console/Haskeline/Command/KillRing.hs
+++ b/System/Console/Haskeline/Command/KillRing.hs
@@ -55,14 +55,14 @@ deleteFromDiff' (IMode xs1 ys1) (IMode xs2 ys2)
 killFromHelper :: (MonadState KillRing m, MonadState Undo m,
                         Save s, Save t)
                 => KillHelper -> Command m s t
-killFromHelper helper = saveForUndo >|> \oldS -> do
+killFromHelper helper = saveForUndo >=> \oldS -> do
     let (gs,newIM) = applyHelper helper (save oldS)
     modify (push gs)
     setState (restore newIM)
 
 killFromArgHelper :: (MonadState KillRing m, MonadState Undo m, Save s, Save t)
                 => KillHelper -> Command m (ArgMode s) t
-killFromArgHelper helper = saveForUndo >|> \oldS -> do
+killFromArgHelper helper = saveForUndo >=> \oldS -> do
     let (gs,newIM) = applyArgHelper helper (fmap save oldS)
     modify (push gs)
     setState (restore newIM)

--- a/System/Console/Haskeline/Emacs.hs
+++ b/System/Console/Haskeline/Emacs.hs
@@ -13,6 +13,7 @@ import System.Console.Haskeline.Command.KillRing
 import System.Console.Haskeline.LineState
 import System.Console.Haskeline.InputT
 
+import Control.Monad ((>=>))
 import Control.Monad.Catch (MonadMask)
 import Data.Char
 
@@ -32,7 +33,7 @@ enders = choiceCmd [simpleChar '\n' +> finish, eotKey +> deleteCharOrEOF]
         deleteCharOrEOF s
             | s == emptyIM  = return Nothing
             | otherwise = change deleteNext s >>= justDelete
-        justDelete = keyChoiceCmd [eotKey +> change deleteNext >|> justDelete
+        justDelete = keyChoiceCmd [eotKey +> change deleteNext >=> justDelete
                             , emacsCommands]
 
 

--- a/System/Console/Haskeline/Internal.hs
+++ b/System/Console/Haskeline/Internal.hs
@@ -9,6 +9,8 @@ import System.Console.Haskeline.Monads
 import System.Console.Haskeline.RunCommand
 import System.Console.Haskeline.Term
 
+import Control.Monad ((>=>))
+
 -- | This function may be used to debug Haskeline's input.
 --
 -- It loops indefinitely; every time a key is pressed, it will
@@ -33,5 +35,5 @@ debugTerminalKeys = runInputT defaultSettings $ do
                 effect (LineChange $ const ([],[]))
                 effect (PrintLines [show k])
                 setState emptyIM)
-            >|> keyCommand loop
+            >=> keyCommand loop
     prompt = stringToGraphemes "> "

--- a/System/Console/Haskeline/Monads.hs
+++ b/System/Console/Haskeline/Monads.hs
@@ -84,7 +84,7 @@ instance MonadIO m => MonadState s (ReaderT (IORef s) m) where
     put s = ask >>= liftIO . flip writeIORef s
 
 evalStateT' :: Monad m => s -> StateT s m a -> m a
-evalStateT' s f = liftM fst $ runStateT f s
+evalStateT' = flip evalStateT
 
 orElse :: Monad m => MaybeT m a -> m a -> m a
 orElse (MaybeT f) g = f >>= maybe g return


### PR DESCRIPTION
While investigating https://github.com/haskell/haskeline/issues/60 and trying to get my head around this code, I've realized that a `>|>` operator is defined that is no more than the fish operator `Control.Monad.(>=>)`, just with a different precedence.

I think this makes the code less readable for no benefit, because one has to shove one more symbol in their head, plus the memory to remember it has a given meaning, so with this change I'm substituting `>|>` with `>=>` throughout.

Clearly, to avoid having to put `(...)` here and there, I also changed the precedence of `+>` which is often used with that.

The code `cabal build`s, which I suppose is enough for this type of change?